### PR TITLE
feat: split Engineering Mathematics into 5 CDU-aligned courses

### DIFF
--- a/docs/degree_mapping.md
+++ b/docs/degree_mapping.md
@@ -17,14 +17,14 @@ new course development. Update when new courses are added to the platform.
 
 | Code | Unit Name | Platform Course | Coverage |
 |------|-----------|-----------------|----------|
-| SMA101 | Mathematics 1A | Engineering Mathematics (001A–003A Basic Arithmetic → Pre-Calculus) | ✅ |
-| SMA102 | Mathematics 1B | Engineering Mathematics (004A–007A Differential → Multivariable Calculus) | ✅ |
-| SMA209 | Mathematics 2A | Engineering Mathematics (007A–010B Linear Algebra → Laplace Transforms) | ✅ |
+| SMA101 | Mathematics 1A | Mathematics 1A (SMA101) | ✅ |
+| SMA102 | Mathematics 1B | Mathematics 1B (SMA102) | ✅ |
+| SMA209 | Mathematics 2A | Mathematics 2 (SMA209) | ✅ |
 | ENG151 | Statics | — | 🔲 |
 | ENG252 | Dynamics | — | 🔲 |
 | ENG175 | Internet of Things | Embedded Systems (009A IoT & Connectivity), Networking Fundamentals | ⚡ |
 | HIT137 | Software Now | — | 🔲 |
-| SMA212 | Data Analytics | — | 🔲 |
+| SMA212 | Data Analytics | Data Analytics (SMA212) | ✅ |
 | ENG305 | Safety, Risk and Reliability | Industrial Automation & Robotics (009A Functional Safety IEC 61508) | ⚡ |
 | PMO201 | Project Management | — | — |
 | ENG410 | Professional Practice for Engineers | — | — |
@@ -51,7 +51,8 @@ new course development. Update when new courses are added to the platform.
 | ENG365 | C Programming | — | 🔲 |
 | HIT391 | Machine Learning: Advancements and Applications | — | 🔲 |
 
-**EE coverage summary:** 10/14 technical units covered · 4 gaps · 5 out-of-scope
+**EE coverage summary:** 11/14 technical units covered · 3 gaps (ENG229, ENG377/573, ENG365) · 5 out-of-scope
+Note: SMA212 Data Analytics now covered. Foundation Mathematics (FOUND101) is a bonus pre-university bridging course not in the CDU EE degree list.
 
 ---
 
@@ -59,8 +60,8 @@ new course development. Update when new courses are added to the platform.
 
 | Code | Unit Name | Platform Course | Coverage |
 |------|-----------|-----------------|----------|
-| SMA101 | Mathematics 1A | Engineering Mathematics (001A–003A) | ✅ |
-| SMA102 | Mathematics 1B | Engineering Mathematics (004A–007A) | ✅ |
+| SMA101 | Mathematics 1A | Mathematics 1A (SMA101) | ✅ |
+| SMA102 | Mathematics 1B | Mathematics 1B (SMA102) | ✅ |
 | HIT172 | Operating Systems and Applications | Linux Fundamentals (LFCA) | ⚡ |
 | HIT274 | Network Engineering Applications | Networking Fundamentals | ✅ |
 | ENG229 | Digital Systems and Computer Architecture | — | 🔲 |
@@ -80,6 +81,7 @@ new course development. Update when new courses are added to the platform.
 | HIT401 | Capstone Project | — | — |
 
 **CS coverage summary:** 4/17 technical units covered · 13 gaps · 2 out-of-scope
+Note: SMA101 and SMA102 now have dedicated courses. SMA212/HIT140 gap remains (Data Analytics covers SMA212 topics but HIT140 may need extra content).
 
 ---
 
@@ -92,7 +94,7 @@ Ordered by: (a) appears in both degrees, (b) technical depth suited to flashcard
 | 1 | ENG229 | Digital Systems & Computer Architecture | Shared by both degrees. Logic gates → ISA → microarchitecture → pipelines |
 | 2 | ENG365 | C Programming | Shared. Syntax, pointers, memory, embedded C patterns |
 | 3 | ENG573, ENG377 | Communication Systems & Electromagnetics | EE core. Modulation, antennas, Maxwell's equations |
-| 4 | HIT140, SMA212 | Data Science & Analytics | Shared interest. Stats, pandas, ML foundations |
+| 4 | HIT140 | Data Science (foundations) | SMA212 now covered by Data Analytics course. HIT140 may need additional content (EDA, feature engineering) |
 | 5 | HIT220 | Algorithms & Complexity | CS core. Big-O, sorting, graphs, dynamic programming |
 | 6 | HIT333 | Cyber Security | Expand existing Network Security topic into full course |
 | 7 | HIT172 | Operating Systems | Expand Linux Fundamentals or add a dedicated OS course |
@@ -118,4 +120,4 @@ of the unit outline PDF text is ideal.
 
 ---
 
-*Last updated: 2026-02-26*
+*Last updated: 2026-02-26 — mathematics restructure (migration 0029)*

--- a/project_longterm.md
+++ b/project_longterm.md
@@ -97,7 +97,11 @@ Blank-code topics sort first within a course (user-created topics in practice).
 
 | Course | Topics |
 |--------|--------|
-| Engineering Mathematics | 001A Basic Arithmetic & Number Sense, 001B Algebra Fundamentals, 002A Geometry, 002B Trigonometry Fundamentals, 003A Pre-Calculus, 004A Differential Calculus, 005A Integral Calculus, 006A Multivariable Calculus, 007A Linear Algebra, 008A Ordinary Differential Equations (ODEs), 009A Partial Differential Equations (PDEs), 010A Fourier Analysis, 010B Laplace Transforms |
+| Foundation Mathematics (FOUND101) | 001A Basic Arithmetic & Number Sense, 001B Algebra Fundamentals, 002A Geometry, 002B Trigonometry Fundamentals, 003A Pre-Calculus |
+| Mathematics 1A (SMA101) | 001A Functions & Limits, 001B Continuity & Exponential Functions, 002A Differential Calculus, 002B Curve Sketching & Optimisation, 003A Integral Calculus, 003B Applications of Integration, 004A Complex Numbers, 004B Vectors in 2D & 3D, 005A Linear Algebra, 005B Systems of Linear Equations |
+| Mathematics 1B (SMA102) | 001A Advanced Integration Techniques, 001B Volumes Surface Areas & Applications, 002A Numerical Methods, 003A Vector Spaces & Linear Transformations, 003B Eigenvalues & Eigenvectors, 004A Multivariable Calculus, 004B Vector Functions & Line Integrals, 005A Surface Integrals & Green's Theorem, 005B Gauss's Divergence Theorem |
+| Mathematics 2 (SMA209) | 001A Ordinary Differential Equations (ODEs), 001B Second-Order ODEs (Homogeneous), 002A Second-Order ODEs (Non-Homogeneous), 002B Systems of ODEs, 003A Fourier Analysis, 003B Fourier Transforms, 004A Laplace Transforms, 004B Laplace Transforms — Applications, 009A Partial Differential Equations (PDEs) |
+| Data Analytics (SMA212) | 001A–010A (Descriptive Statistics → Python & Pandas for Data Analytics) |
 | Circuit Analysis Fundamentals | 001A–006A (DC Circuit Analysis → AC Power Analysis) |
 | Analog Electronics | 001A–010A (Signals & Amplifiers → Oscillators) |
 | Digital Signal Processing | 001A–010A (Sinusoids & Phasors → MATLAB for DSP) |
@@ -109,7 +113,7 @@ Blank-code topics sort first within a course (user-created topics in practice).
 | Networking Fundamentals | 001A–008A (OSI Model & TCP/IP → Industrial Networking) |
 | Industrial Automation & Robotics | 001A–009A (PLC Fundamentals → Functional Safety (IEC 61508)) |
 
-Full detail is in `study/migrations/0027_set_topic_codes.py`.
+Full detail is in `study/migrations/0027_set_topic_codes.py` (original EE/CS courses) and `study/migrations/0029_restructure_mathematics.py` (mathematics split).
 
 ### Adding a new system topic
 

--- a/project_shortterm.md
+++ b/project_shortterm.md
@@ -9,10 +9,10 @@ Update this file whenever work is completed or priorities shift.
 
 | PR | Branch | Description | Status |
 |----|--------|-------------|--------|
-| #41 | `feature/curriculum-population` | 11 courses, 95 topics, 873 flashcards seeded via migrations 0013–0024; auto-enrollment on register | Awaiting merge |
-| #42 | `feature/topic-code-ordering` | Topic `code` field (001A/001B/002A scheme); migrations 0026–0027; template display | Awaiting merge |
+| #42 | `feature/topic-code-ordering` | Topic `code` field (001A/001B/002A scheme); migrations 0026–0028; template display | Awaiting merge |
+| — | `feature/mathematics-restructure` | Split Engineering Mathematics into 5 courses (migration 0029); Data Analytics added | Awaiting PR creation |
 
-**Merge order matters:** #41 must merge before #42 (0026/0027 depend on the topics created by 0013–0024).
+**Merge order matters:** #42 must merge before `feature/mathematics-restructure` (0029 depends on topics created by 0013–0024 and the code field from 0026).
 
 ---
 
@@ -24,6 +24,11 @@ Update this file whenever work is completed or priorities shift.
 - **Codes documented in migration 0013** but applied by migration 0027, because 0013 runs
   before the `code` column is added (0026). This is by design — see comment in 0013.
 
+- **Engineering Mathematics split** (2026-02-26): Single 13-topic course replaced by five
+  CDU-aligned courses via migration 0029: Foundation Mathematics (FOUND101), Mathematics 1A
+  (SMA101), Mathematics 1B (SMA102), Mathematics 2 (SMA209), Data Analytics (SMA212).
+  Total topics: 43 (5 + 10 + 9 + 9 + 10). Existing flashcards move with their topics.
+
 - **`CardFeedback` model deleted** (earlier): `test_security_and_modes` still imports it
   and fails. Pre-existing, unrelated to current work — leave it for a future cleanup PR.
 
@@ -31,11 +36,12 @@ Update this file whenever work is completed or priorities shift.
 
 ## Immediate Priorities
 
-1. Merge PR #41 (curriculum population) — prerequisite for everything else.
-2. Merge PR #42 (topic codes) — depends on #41.
-3. After merge: add `topic-code` CSS styling (`span.topic-code`) to the base stylesheet
+1. Merge PR #42 (topic codes) — prerequisite for mathematics-restructure.
+2. Create and merge PR for `feature/mathematics-restructure` — depends on #42.
+3. After merges: add `topic-code` CSS styling (`span.topic-code`) to the base stylesheet
    so the code renders visually distinct from the topic name.
-4. Decide on next feature area — candidates:
+4. Add flashcard content for the 30 new topics in SMA101, SMA102, SMA209, SMA212.
+5. Decide on next feature area — candidates:
    - SM-2 spaced repetition algorithm (currently only tracking confidence level)
    - Learning feedback loop (suggest prerequisite review on wrong answers)
    - Progress dashboard

--- a/study/migrations/0029_restructure_mathematics.py
+++ b/study/migrations/0029_restructure_mathematics.py
@@ -1,0 +1,239 @@
+"""
+Migration 0029 — Restructure Mathematics
+
+Splits the single "Engineering Mathematics" course into five courses that mirror
+the actual CDU units a student takes:
+
+  Foundation Mathematics (FOUND101)  — pre-university / bridging
+  Mathematics 1A         (SMA101)    — CDU SMA101
+  Mathematics 1B         (SMA102)    — CDU SMA102
+  Mathematics 2          (SMA209)    — CDU SMA209
+  Data Analytics         (SMA212)    — CDU SMA212 (new content)
+
+Steps
+-----
+1. Create the five new courses under the system user.
+2. Move existing topics from Engineering Mathematics to their new home,
+   updating each topic's `code` to its new position in the new course.
+3. Create new topics that were absent from the old Engineering Mathematics course.
+4. Delete Engineering Mathematics (now empty).
+5. Back-fill CourseEnrollment for all non-system users for the five new courses.
+
+Idempotent: get_or_create / filter().update() with guards throughout.
+Reverse: intentional no-op (see reverse_func).
+"""
+
+from django.db import migrations
+
+# ---------------------------------------------------------------------------
+# Topic assignments
+# ---------------------------------------------------------------------------
+
+# Topics to MOVE from Engineering Mathematics to a new course.
+# Structure: (old_topic_name, new_course_code, new_topic_code)
+MOVES = [
+    # → Foundation Mathematics
+    ("Basic Arithmetic & Number Sense",      "FOUND101", "001A"),
+    ("Algebra Fundamentals",                 "FOUND101", "001B"),
+    ("Geometry",                             "FOUND101", "002A"),
+    ("Trigonometry Fundamentals",            "FOUND101", "002B"),
+    ("Pre-Calculus",                         "FOUND101", "003A"),
+    # → Mathematics 1A
+    ("Differential Calculus",                "SMA101",   "002A"),
+    ("Integral Calculus",                    "SMA101",   "003A"),
+    ("Linear Algebra",                       "SMA101",   "005A"),
+    # → Mathematics 1B
+    ("Multivariable Calculus",               "SMA102",   "004A"),
+    # → Mathematics 2
+    ("Ordinary Differential Equations (ODEs)", "SMA209", "001A"),
+    ("Fourier Analysis",                     "SMA209",   "003A"),
+    ("Laplace Transforms",                   "SMA209",   "004A"),
+    ("Partial Differential Equations (PDEs)", "SMA209",  "009A"),
+]
+
+# Brand-new topics to CREATE in new courses.
+# Structure: (course_code, topic_code, topic_name)
+NEW_TOPICS = [
+    # Mathematics 1A — SMA101
+    ("SMA101", "001A", "Functions & Limits"),
+    ("SMA101", "001B", "Continuity & Exponential Functions"),
+    ("SMA101", "002B", "Curve Sketching & Optimisation"),
+    ("SMA101", "003B", "Applications of Integration"),
+    ("SMA101", "004A", "Complex Numbers"),
+    ("SMA101", "004B", "Vectors in 2D & 3D"),
+    ("SMA101", "005B", "Systems of Linear Equations"),
+    # Mathematics 1B — SMA102
+    ("SMA102", "001A", "Advanced Integration Techniques"),
+    ("SMA102", "001B", "Volumes, Surface Areas & Applications"),
+    ("SMA102", "002A", "Numerical Methods"),
+    ("SMA102", "003A", "Vector Spaces & Linear Transformations"),
+    ("SMA102", "003B", "Eigenvalues & Eigenvectors"),
+    ("SMA102", "004B", "Vector Functions & Line Integrals"),
+    ("SMA102", "005A", "Surface Integrals & Green's Theorem"),
+    ("SMA102", "005B", "Gauss's Divergence Theorem"),
+    # Mathematics 2 — SMA209
+    ("SMA209", "001B", "Second-Order ODEs (Homogeneous)"),
+    ("SMA209", "002A", "Second-Order ODEs (Non-Homogeneous)"),
+    ("SMA209", "002B", "Systems of ODEs"),
+    ("SMA209", "003B", "Fourier Transforms"),
+    ("SMA209", "004B", "Laplace Transforms — Applications"),
+    # Data Analytics — SMA212
+    ("SMA212", "001A", "Descriptive Statistics & Visualisation"),
+    ("SMA212", "002A", "Inferential Statistics"),
+    ("SMA212", "003A", "Data Preprocessing"),
+    ("SMA212", "004A", "Clustering Methods"),
+    ("SMA212", "005A", "Frequent Pattern Mining"),
+    ("SMA212", "006A", "Regression Analysis"),
+    ("SMA212", "007A", "Classification Algorithms"),
+    ("SMA212", "008A", "Big Data Concepts"),
+    ("SMA212", "009A", "Data Ethics, Privacy & Ownership"),
+    ("SMA212", "010A", "Python & Pandas for Data Analytics"),
+]
+
+# Course definitions: (code, name, description)
+NEW_COURSES = [
+    (
+        "FOUND101",
+        "Foundation Mathematics",
+        (
+            "Pre-university bridging course covering arithmetic, algebra, geometry, "
+            "trigonometry, and pre-calculus. Recommended before SMA101."
+        ),
+    ),
+    (
+        "SMA101",
+        "Mathematics 1A",
+        (
+            "CDU SMA101 — functions, limits, continuity, differential and integral calculus, "
+            "complex numbers, vectors, and an introduction to linear algebra."
+        ),
+    ),
+    (
+        "SMA102",
+        "Mathematics 1B",
+        (
+            "CDU SMA102 — multivariable calculus, advanced integration, numerical methods, "
+            "vector calculus, linear algebra, and surface/line integrals."
+        ),
+    ),
+    (
+        "SMA209",
+        "Mathematics 2",
+        (
+            "CDU SMA209 — ordinary and partial differential equations, systems of ODEs, "
+            "Fourier analysis, Fourier transforms, and Laplace transform applications."
+        ),
+    ),
+    (
+        "SMA212",
+        "Data Analytics",
+        (
+            "CDU SMA212 — statistics, data preprocessing, clustering, pattern mining, "
+            "regression, classification, big data, data ethics, and Python/Pandas."
+        ),
+    ),
+]
+
+
+def restructure_mathematics(apps, schema_editor):
+    Course = apps.get_model("study", "Course")
+    Topic = apps.get_model("study", "Topic")
+    CourseEnrollment = apps.get_model("study", "CourseEnrollment")
+    User = apps.get_model("auth", "User")
+
+    # Fetch system user
+    try:
+        system_user = User.objects.get(username="system")
+    except User.DoesNotExist:
+        # Nothing to do on a blank install — courses come from 0013 which
+        # already uses the same system user.
+        return
+
+    # ------------------------------------------------------------------
+    # 1. Create (or retrieve) the five new courses
+    # ------------------------------------------------------------------
+    course_map = {}  # code → Course instance
+    for code, name, description in NEW_COURSES:
+        course, _ = Course.objects.get_or_create(
+            code=code,
+            defaults={
+                "name": name,
+                "description": description,
+                "created_by": system_user,
+            },
+        )
+        course_map[code] = course
+
+    # ------------------------------------------------------------------
+    # 2. Move existing topics from Engineering Mathematics
+    # ------------------------------------------------------------------
+    try:
+        eng_math = Course.objects.get(
+            name="Engineering Mathematics",
+            created_by=system_user,
+        )
+    except Course.DoesNotExist:
+        eng_math = None  # already restructured on a previous run
+
+    if eng_math is not None:
+        for old_name, new_course_code, new_code in MOVES:
+            Topic.objects.filter(
+                course=eng_math,
+                name=old_name,
+            ).update(
+                course=course_map[new_course_code],
+                code=new_code,
+            )
+
+    # ------------------------------------------------------------------
+    # 3. Create new topics that didn't exist in Engineering Mathematics
+    # ------------------------------------------------------------------
+    for course_code, topic_code, topic_name in NEW_TOPICS:
+        Topic.objects.get_or_create(
+            course=course_map[course_code],
+            name=topic_name,
+            defaults={"code": topic_code, "order": 0},
+        )
+        # In case it already exists but code wasn't set (idempotent guard)
+        Topic.objects.filter(
+            course=course_map[course_code],
+            name=topic_name,
+            code="",
+        ).update(code=topic_code)
+
+    # ------------------------------------------------------------------
+    # 4. Delete Engineering Mathematics (should now be empty)
+    # ------------------------------------------------------------------
+    if eng_math is not None:
+        remaining = Topic.objects.filter(course=eng_math).count()
+        if remaining == 0:
+            eng_math.delete()
+
+    # ------------------------------------------------------------------
+    # 5. Back-fill CourseEnrollment for all non-system users
+    # ------------------------------------------------------------------
+    non_system_users = User.objects.exclude(username="system")
+    for user in non_system_users:
+        for course in course_map.values():
+            CourseEnrollment.objects.get_or_create(
+                user=user,
+                course=course,
+                defaults={"status": "studying"},
+            )
+
+
+def reverse_func(apps, schema_editor):
+    # Intentional no-op: reversing a destructive restructure is not safe
+    # without a full data backup.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("study", "0028_alter_topic_options_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(restructure_mathematics, reverse_func),
+    ]


### PR DESCRIPTION
## Summary

- Migration 0029 replaces the single \"Engineering Mathematics\" course with five courses matching actual CDU units: **Foundation Mathematics** (FOUND101), **Mathematics 1A** (SMA101), **Mathematics 1B** (SMA102), **Mathematics 2** (SMA209), and **Data Analytics** (SMA212)
- 13 existing topics moved to their correct courses with updated codes; 30 new topics created from CDU unit outlines (SMA101, SMA102, SMA209, SMA212)
- Existing flashcards travel with their topics automatically (FK to Topic)
- All non-system users back-filled with CourseEnrollment for the 5 new courses
- `docs/degree_mapping.md`, `project_longterm.md`, `project_shortterm.md` updated

## Depends on

Merge PR #42 (`feature/topic-code-ordering`) first — 0029 requires the `code` field (0026) and existing system topics (0013–0024).

## Test Plan

- [x] `venv/bin/python -m py_compile study/migrations/0029_restructure_mathematics.py` — OK
- [x] `venv/bin/python manage.py migrate` — applied cleanly
- [x] Shell verify: all 5 courses present with correct topic counts (5/10/9/9/10) and codes
- [x] Engineering Mathematics confirmed deleted
- [x] `venv/bin/python manage.py test study --verbosity=1` — 59/60 pass; 1 pre-existing failure (`test_security_and_modes` imports deleted `CardFeedback` — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)